### PR TITLE
more checks around blockchain tests

### DIFF
--- a/test/tools/jsontests/BlockChainTests.cpp
+++ b/test/tools/jsontests/BlockChainTests.cpp
@@ -43,7 +43,10 @@ eth::Network TestBlockChain::s_sealEngineNetwork = eth::Network::FrontierTest;
 json_spirit::mValue BlockchainTestSuite::doTests(json_spirit::mValue const& _input, bool _fillin) const
 {
 	json_spirit::mObject tests;
-	for (auto const& i : _input.get_obj())
+    BOOST_REQUIRE_MESSAGE(
+        _input.get_obj().size() > 0, "A blockchain test should contain at least one test! " +
+                                         TestOutputHelper::get().testFile().string());
+    for (auto const& i : _input.get_obj())
 	{
 		string const& testname = i.first;
 		json_spirit::mObject const& inputTest = i.second.get_obj();

--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -121,6 +121,11 @@ void ImportTest::makeBlockchainTestFromStateTest(set<eth::Network> const& _netwo
                         }
                     }
 
+                    BOOST_REQUIRE_MESSAGE(obj.size() > 0,
+                        "There should be at least one result in expect section for a "
+                        "transaction! " +
+                            TestOutputHelper::get().testName());
+
                     json_spirit::mObject expetSectionObj;
                     expetSectionObj["network"] = test::netIdToString(net);
                     expetSectionObj["result"] = obj;
@@ -130,6 +135,8 @@ void ImportTest::makeBlockchainTestFromStateTest(set<eth::Network> const& _netwo
             }  // for exp
         }      // for net
 
+        BOOST_REQUIRE_MESSAGE(expetSectionArray.size() > 0,
+            "There should be at least one expect section in the test filler! " + testname);
         testObj["expect"] = expetSectionArray;
 
         // rewrite header section for a block by the statetest parameters
@@ -635,9 +642,9 @@ bool ImportTest::checkGeneralTestSectionSearch(json_spirit::mObject const& _expe
     else
     {
         // Expect section in filled test
-        requireJsonFields(_expects, "expect",
-            {{"indexes", jsonVType::obj_type}, {"hash", jsonVType::str_type},
-                {"logs", jsonVType::str_type}});
+        // requireJsonFields(_expects, "expect",
+        //    {{"indexes", jsonVType::obj_type}, {"hash", jsonVType::str_type},
+        //        {"logs", jsonVType::str_type}});
     }
 
     vector<int> d;


### PR DESCRIPTION
there was an issue with empty blockchain tests after disabling the transactions with no expect section. 

a test filler was generated with empty expect section and empty expect section produced an empty blockchain test. 
this fix checks bc tests for emptyness 

the test fix 
https://github.com/ethereum/tests/pull/418